### PR TITLE
move nolints script to this repo

### DIFF
--- a/.github/workflows/nolints.yml
+++ b/.github/workflows/nolints.yml
@@ -42,7 +42,6 @@ jobs:
           ./scripts/mk_all.sh
           lean --run scripts/lint_mathlib.lean
           mv nolints.txt scripts/nolints.txt
-          ./scripts/rm_all.sh
           git diff
 
       - name: configure git setup


### PR DESCRIPTION
This is almost directly copied from mathlib except for the `repository` line in the checkout and the secret name.