### PR TITLE
mk_bundle.py: fix macOS portable mode

### DIFF
--- a/mk_bundle.py
+++ b/mk_bundle.py
@@ -231,6 +231,7 @@ def mk_launcher() -> None:
     MAC_BASH_SCRIPT = """#!/bin/bash
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
     cd $DIR
+    xattr -dr com.apple.quarantine ./vscodium/VSCodium.app/
     open ./vscodium/VSCodium.app --args $DIR/src
     """
     with (DIST_MAC/'trylean').open('w') as path:


### PR DESCRIPTION
It was pointed out [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/simplify.20nat-semiring/near/209131017) that on macOS the extension in VSCodium doesn't seem to work. I tried it out myself and found that it was due to VSCodium not launching in portable mode.

I added an extra line to the `trylean` script following the instructions [here](https://code.visualstudio.com/docs/editor/portable#_macos) and it seemed to fix things locally. 

For some reason [the `trylean_darwin` bundle on Azure](https://oleanstorage.azureedge.net/releases/bundles/trylean_darwin.tar.gz) doesn't seem to have the updated version of the script yet, despite the github actions workflow [saying that it was uploaded](https://github.com/leanprover-community/azure-scripts/runs/1074619287?check_suite_focus=true#step:8:23) (see also #3).