### PR TITLE
adapt azure cleanup script to allow caches from non-mathlib repos

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -27,4 +27,4 @@ jobs:
         pip install gitpython azure-storage-blob
 
     - name: Delete archives
-      run: python cleanup.py "${{ secrets.AZURE_CONNECTION_STRING }}"
+      run: python cleanup.py "${{ secrets.AZURE_CONNECTION_STRING }}" "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -3,7 +3,6 @@ name: delete old archives from Azure
 on:
   schedule:
    - cron: '0 1 * * *'
-  push:
 
 jobs:
   delete_old_archives:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -3,6 +3,7 @@ name: delete old archives from Azure
 on:
   schedule:
    - cron: '0 1 * * *'
+  push:
 
 jobs:
   delete_old_archives:

--- a/cleanup.py
+++ b/cleanup.py
@@ -1,4 +1,4 @@
-# usage: python3 cleanup.py CONNECT_STR
+# usage: python3 cleanup.py CONNECT_STR GITHUB_TOKEN
 
 import os, uuid, datetime, sys
 import git
@@ -7,25 +7,40 @@ from azure.storage.blob import BlobServiceClient, BlobClient, ContainerClient
 # set up git repo
 cloned_repo = git.Repo('mathlib')
 
-branch_heads = set([r.commit.hexsha for r in cloned_repo.refs])
-master_commits = set([c.hexsha for c in cloned_repo.iter_commits('master')])
-
+mathlib_branch_heads = set([r.commit.hexsha for r in cloned_repo.refs])
+mathlib_master_commits = set([c.hexsha for c in cloned_repo.iter_commits('master')])
+external_repo_info = {}
+github_token = sys.argv[2]
 
 #save non-head, non-master commits for this many seconds
 DURATION = datetime.timedelta(days=3) 
 current_time = datetime.datetime.now(datetime.timezone.utc)
 
-def is_deletable(sha, creation_time):
-    return sha not in branch_heads \
-           and sha not in master_commits \
-           and current_time - creation_time > DURATION
+def is_deletable_mathlib(sha, creation_time):
+    return sha not in mathlib_branch_heads \
+            and sha not in mathlib_master_commits \
+            and current_time - creation_time > DURATION
+
+# archives from e.g. lean-liquid are only saved if they come from recent master commits
+def is_deletable_external(repo, sha, creation_time):
+    if repo not in external_repo_info:
+        new_cloned_repo = git.Repo.clone_from(f'https://{github_token}@github.com/leanprover-community/{repo}.git',repo)
+        external_repo_info[repo] = {'branch_heads': set([r.commit.hexsha for r in new_cloned_repo.refs]), 'master_commits': set([c.hexsha for c in new_cloned_repo.iter_commits('master')])}
+    return sha not in external_repo_info[repo]['master_commits'] or current_time - creation_time > DURATION
+
+def is_deletable(path, creation_time):
+    if '/' not in path: # this archive came from mathlib 
+        return is_deletable_mathlib(path, creation_time)
+    else:
+        components = path.split('/')
+        return is_deletable_external(components[0], components[-1], creation_time)
+        
 
 
 # azure configuration
 connect_str = sys.argv[1]
 blob_service_client = BlobServiceClient.from_connection_string(connect_str)
 container_client = blob_service_client.get_container_client('mathlib')
-
 
 def get_deletable_blobs():
     blob_list = list(container_client.list_blobs())
@@ -34,8 +49,8 @@ def get_deletable_blobs():
     print(len(deletable), 'out of', len(blob_list), 'can be deleted, so we keep', 
           len(blob_list) - len(deletable))
 
-    on_master = [blob for blob in blob_list if blob.name[:-7] in master_commits]
-    branch_head = [blob for blob in blob_list if blob.name[:-7] in branch_heads]
+    on_master = [blob for blob in blob_list if blob.name[:-7] in mathlib_master_commits]
+    branch_head = [blob for blob in blob_list if blob.name[:-7] in mathlib_branch_heads]
     new = [blob for blob in blob_list if current_time - blob.last_modified < DURATION]
 
     print(len(on_master), 'are commits to master')

--- a/cleanup.py
+++ b/cleanup.py
@@ -26,7 +26,7 @@ def is_deletable_external(repo, sha, creation_time):
     if repo not in external_repo_info:
         new_cloned_repo = git.Repo.clone_from(f'https://{github_token}@github.com/leanprover-community/{repo}.git',repo)
         external_repo_info[repo] = {'branch_heads': set([r.commit.hexsha for r in new_cloned_repo.refs]), 'master_commits': set([c.hexsha for c in new_cloned_repo.iter_commits('master')])}
-    return sha not in external_repo_info[repo]['master_commits'] or current_time - creation_time > DURATION
+    return sha not in external_repo_info[repo]['master_commits'] or (current_time - creation_time > DURATION and sha != new_cloned_repo.rev_parse('origin/master'))
 
 def is_deletable(path, creation_time):
     if '/' not in path: # this archive came from mathlib 


### PR DESCRIPTION
A companion to https://github.com/leanprover-community/lean-liquid/pull/48

This allows non-mathlib leanprover-community repos to store caches on Azure. The deletion conditions are tailored for lean-liquid right now: only master commits are kept and only for three days. This is easy enough to change.