### PR TITLE
fix random issue bot

### DIFF
--- a/.github/workflows/random_issue.yml
+++ b/.github/workflows/random_issue.yml
@@ -1,11 +1,9 @@
 name: post triage issues on Zulip
 
-# Triage bot is broken
-# https://github.com/leanprover-community/azure-scripts/issues/10
-
-# on:
-#   schedule:
-#    - cron: '0 14 * * *'
+on:
+  push:
+  # schedule:
+  #  - cron: '0 14 * * *'
 
 jobs:
   post_issues:

--- a/.github/workflows/random_issue.yml
+++ b/.github/workflows/random_issue.yml
@@ -1,9 +1,8 @@
 name: post triage issues on Zulip
 
 on:
-  push:
-  # schedule:
-  #  - cron: '0 14 * * *'
+  schedule:
+   - cron: '0 14 * * *'
 
 jobs:
   post_issues:

--- a/post_issue_on_zulip.py
+++ b/post_issue_on_zulip.py
@@ -13,6 +13,7 @@ gh_token = sys.argv[2]
 zulip_client = zulip.Client(email="random-issue-bot@zulipchat.com", api_key=zulip_token, site="https://leanprover.zulipchat.com")
 
 def message_date(id):
+    print(zulip_client.get_message_history(id))
     return zulip_client.get_message_history(id)['message_history'][0]['timestamp']
 
 posted_topics = zulip_client.get_stream_topics(zulip_client.get_stream_id('triage')['stream_id'])['topics']

--- a/post_issue_on_zulip.py
+++ b/post_issue_on_zulip.py
@@ -6,6 +6,7 @@ import github
 import datetime
 import random
 import re
+import time
 
 zulip_token = sys.argv[1]
 gh_token = sys.argv[2]
@@ -13,8 +14,12 @@ gh_token = sys.argv[2]
 zulip_client = zulip.Client(email="random-issue-bot@zulipchat.com", api_key=zulip_token, site="https://leanprover.zulipchat.com")
 
 def message_date(id):
-    print(zulip_client.get_message_history(id))
-    return zulip_client.get_message_history(id)['message_history'][0]['timestamp']
+    history = zulip_client.get_message_history(id)
+    print(history)
+    # We're limited to 200 API calls per minute, this should give us a decent amount of leeway
+    # https://zulip.com/api/rest-error-handling#rate-limit-exceeded
+    time.sleep(0.4)
+    return history['message_history'][0]['timestamp']
 
 posted_topics = zulip_client.get_stream_topics(zulip_client.get_stream_id('triage')['stream_id'])['topics']
 pattern = re.compile(r'#(\d+)')


### PR DESCRIPTION
Turns out we were hitting the API rate limit, so I added a delay (and some logging for future debugging).

The run on commit 6087cfc successfully posted these two messages [1](https://leanprover.zulipchat.com/#narrow/stream/263328-triage/topic/issue.20.232710.3A.20More.20on.20quotients.20of.20categories/near/255773829), [2](https://leanprover.zulipchat.com/#narrow/stream/263328-triage/topic/PR.20.235924.3A.20chore.28data.2Fdfinsupp.29.3A.20Add.20sum_hom/near/255773831), so I think this fixes the issue we were seeing.

Closes #10.