### PR TITLE
Use same deletion logic for lean-liquid as for mathlib

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -21,17 +21,17 @@ def is_deletable_mathlib(sha, creation_time):
             and sha not in mathlib_master_commits \
             and current_time - creation_time > DURATION
 
-# archives from e.g. lean-liquid are only saved if they come from recent master commits
+# archives from e.g. lean-liquid follow the same logic as mathlib
 def is_deletable_external(repo, sha, creation_time):
     if repo not in external_repo_info:
         new_cloned_repo = git.Repo.clone_from(f'https://{github_token}@github.com/leanprover-community/{repo}.git',repo)
         external_repo_info[repo] = {
             'branch_heads': set(r.commit.hexsha for r in new_cloned_repo.refs),
             'master_commits': set(c.hexsha for c in new_cloned_repo.iter_commits('master')),
-            'master_head': new_cloned_repo.rev_parse('origin/master'),
         }
-    return sha not in external_repo_info[repo]['master_commits'] or \
-        (current_time - creation_time > DURATION and sha != external_repo_info[repo]['master_head'])
+    return sha not in external_repo_info[repo]['branch_heads'] \
+        and sha not in external_repo_info[repo]['master_commits'] \
+        and current_time - creation_time > DURATION
 
 def is_deletable(path, creation_time):
     if '/' not in path: # this archive came from mathlib


### PR DESCRIPTION
Development in lean-liquid has moved off master, and we've started storing oleans for non-master branches. Therefore the deletion logic here needs to be updated.

This pull request changes the logic to match that used for mathlib -- but it's your call how the logic should be.

I didn't do a refactor to remove duplication because I don't know if you're okay with the logic being like this, plus I can't test changes to this script without doing painful things.