### PR TITLE
post issues / PRs from mathlib4 instead of mathlib

### DIFF
--- a/post_issue_on_zulip.py
+++ b/post_issue_on_zulip.py
@@ -28,7 +28,7 @@ posted_topics = {int(v[0]): message_date(t['max_id']) for (t, v) in ((t, pattern
 print(posted_topics)
 
 gh = github.Github(login_or_token=gh_token)
-mathlib = gh.get_repo('leanprover-community/mathlib')
+mathlib = gh.get_repo('leanprover-community/mathlib4')
 
 open_items = mathlib.get_issues(state='open')
 open_prs = []


### PR DESCRIPTION
As requested on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/263328-triage/topic/issue.20.231465.3A.20Probably.20.60setup_tactic_parser.60.20can.20be.20integr.2E.2E.2E/near/314565494)