### PR TITLE
Fix a typo in mk_bundle.py

### DIFF
--- a/mk_bundle.py
+++ b/mk_bundle.py
@@ -192,7 +192,7 @@ def get_lean_extension():
             "**/.DS_Store": true,
             "**/*.olean": true
         },
-        "lean.executablePath": "%extensionPath%/../../../../lean/bin/lean"
+        "lean.executablePath": "%extensionPath%/../../../../lean/bin/lean",
         "editor.minimap.enabled": false,
         "window.titleBarStyle": "custom",
     }


### PR DESCRIPTION
This typo may affect users of the Trylean bundle, and cause problems when reading/writing VSCode settings.