### PR TITLE
feat: weekly report on PRs to website and blog

### DIFF
--- a/.github/workflows/weekly_blog_and_website_report.yml
+++ b/.github/workflows/weekly_blog_and_website_report.yml
@@ -1,0 +1,53 @@
+name: Weekly blog and website report
+
+on:
+  schedule:
+    - cron: '0 4 * * WED'  # Run at 04:00 UTC every Wednesday
+  workflow_dispatch:
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+    if: github.repository == 'leanprover-community/mathlib4'
+
+    steps:
+    - name: Checkout website
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: 'leanprover-community/leanprover-community.github.io'
+        path: website
+
+    - name: Checkout blog
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: 'leanprover-community/leanprover-community.github.io'
+        path: blog
+
+    - name: Produce tables
+      id: tables
+      run: |
+        for site in website blog
+        do
+          printf 'PRs in %s\n' "${site}"
+          cd "${site}"
+          printf $'%s<<EOF\n%s\nEOF' "${site}" "$(./formatGhPrList.sh "${site}")" | tee -a "$GITHUB_OUTPUT"
+          cd ..
+        done
+
+    - name: Post output to Zulip
+      uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
+      with:
+        api-key: ${{ secrets.REPO_UPDATE_ZULIP_TOKEN }}
+        email: 'leanprover-community-repo-update-bot@leanprover.zulipchat.com'
+        organization-url: 'https://leanprover.zulipchat.com'
+        to: 'mathlib reviewers'
+        type: 'stream'
+        topic: 'blog and website PRs'
+        content: |
+          ###  Open website PRs
+
+          ${{ steps.tables.outputs.website }}
+
+          ###  Open blog PRs
+
+          ${{ steps.tables.outputs.table }}

--- a/formatGhPrList.sh
+++ b/formatGhPrList.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Running `./formatGhPrList.sh <linkifier>` produces an .md-formatted table
+# of all the issues in the current repository.
+# Assuming that `<linkifier>#NNN` is a valid Zulip linkifier, the PRs will be clickable links.
+
+repo="${1:-linkifier}"
+
+gh pr list |
+  awk -F$'\t' -v link="${repo}#" 'BEGIN{
+    OFS="|"
+    print "", " ID ", " TITLE ", " DATE ", " STATUS ", ""
+    print "", " - ", " - ", " - ", " - ", ""
+  }
+    #(NR == 1){link=""}
+    #(!(NR == 1)){link=lk}
+    # skip the 3rd field, containing the branch name
+    {
+      date=$5
+      gsub(/T.*/, "", date)
+      print "", link $1, $2, date, $4, ""
+    }'


### PR DESCRIPTION
Produces a weekly report of the open PRs to the [website](https://github.com/leanprover-community/leanprover-community.github.io) and the [blog](https://github.com/leanprover-community/blog) and posts it to Zulip.